### PR TITLE
Improve dist creation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,42 @@
 [metadata]
 name = openpaygo
 version = 0.5.2
+description = OpenPAYGO library in Python
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/EnAccess/OpenPAYGO-python/
-description-file=README.md
-license_files=LICENSE
+# author = EnAccess Fundation
+# author_email = info@enaccess.org
+license =  MIT License
+license_files = LICENSE
+project_urls =
+    Homepage = https://enaccess.org/materials/openpaygotoken/
+    # Documentation = https://github.com/EnAccess/OpenPAYGO-python/
+    Changes = https://github.com/EnAccess/OpenPAYGO-python/releases
+    Source = https://github.com/EnAccess/OpenPAYGO-python/
+    Issue Tracker = https://github.com/EnAccess/OpenPAYGO-python//issues
+    Twitter = https://twitter.com/EnAccessFdn
+    Chat = https://community.enaccess.org/
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: Unix
+    Operating System :: POSIX
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Utilities
+keywords =
+    paygo
 
 [options]
 python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 
+# read the contents of your README file
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="openpaygo", 
@@ -8,6 +12,8 @@ setup(
     license='MIT',
     author="Solaris Offgrid",
     url='https://github.com/EnAccess/OpenPAYGO-python/',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     install_requires=[
         'siphash',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-# read the contents of your README file
-from pathlib import Path
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
-
-setup(
-    name="openpaygo", 
-    packages=find_packages(),
-    version='0.5.2',
-    license='MIT',
-    author="Solaris Offgrid",
-    url='https://github.com/EnAccess/OpenPAYGO-python/',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    install_requires=[
-        'siphash',
-    ],
-)
+setup()


### PR DESCRIPTION
- Use `setup.cfg` as single-source of truth. Before `setup.py` would overwrite `setup.cfg` and can cause confusions.
- Populate fields used by PyPI, like `long_description`  and social likes to enables description on PyPI, which is currently empty.

